### PR TITLE
Bring CI up to latest and greatest, drop upper bounds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+name: CI
+
 on:
   pull_request:
   push:
@@ -8,15 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.stack
-            ./.stack-work
-          key: ${{ runner.os }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('*.cabal') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('stack.yaml') }}-
-            ${{ runner.os }}-
+      - uses: freckle/stack-cache-action@v1.0.1
       - uses: freckle/stack-action@v2
         with:
           weeder: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,23 @@
-name: Release to Hackage
+name: Release
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches: main
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    env:
-      HACKAGE_API_KEY: ${{ secrets.HACKAGE_API_KEY }}
     steps:
       - uses: actions/checkout@v2
-      - uses: freckle/stack-upload-action@main
+
+      - id: tag
+        uses: freckle/haskell-tag-action@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: steps.tag.outputs.tag
+        uses: freckle/stack-upload-action@main
         with:
-          pvp-bounds: both
+          pvp-bounds: lower
+        env:
+          HACKAGE_API_KEY: ${{ secrets.HACKAGE_UPLOAD_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-*.cabal
 .stack-work

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-## [_Unreleased_](https://github.com/freckle/hspec-expectations-json/compare/v1.0.0.3...master)
+## [_Unreleased_](https://github.com/freckle/hspec-expectations-json/compare/v1.0.0.4...main)
 
 None
+
+## [v1.0.0.4](https://github.com/freckle/hspec-expectations-json/compare/v1.0.0.3...v1.0.0.4)
+
+- Remove dependencies upper bounds
 
 ## [v1.0.0.3](https://github.com/freckle/hspec-expectations-json/compare/v1.0.0.2...v1.0.0.3)
 

--- a/hspec-expectations-json.cabal
+++ b/hspec-expectations-json.cabal
@@ -1,0 +1,83 @@
+cabal-version: 1.18
+
+-- This file has been generated from package.yaml by hpack version 0.33.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: eaa28bc0afd1506a694704594f47f76a1f71fe9b86f6bfa18ceab1e2f65c837e
+
+name:           hspec-expectations-json
+version:        1.0.0.4
+synopsis:       Hspec expectations for JSON Values
+description:    Hspec expectations for JSON Values
+                .
+                Comparing JSON `Value`s in Haskell tests comes with some challenges:
+                .
+                - In API responses, additive changes are typically safe and an important way
+                  to evolve responses without breaking clients. Therefore, assertions against
+                  such responses often want to ignore any unexpected keys in `Object`s (at any
+                  depth), as any clients would.
+                .
+                - Order often doesn't matter in API responses either, so it should be possible
+                  to assert equality regardless of `Array` ordering (again, at any depth).
+                .
+                - When an assertion fails, showing the difference clearly needs to take the
+                  above into account (i.e. it can't show keys you've ignored, or ordering
+                  differences you didn't care about), and it has to display things clearly,
+                  e.g. as a diff.
+                .
+                This library handles all these things.
+category:       Test
+homepage:       https://github.com/freckle/hspec-expectations-json#readme
+bug-reports:    https://github.com/freckle/hspec-expectations-json/issues
+author:         Freckle Engineering
+maintainer:     engineering@freckle.com
+copyright:      2020 Freckle Education
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-doc-files:
+    CHANGELOG.md
+    README.md
+
+source-repository head
+  type: git
+  location: https://github.com/freckle/hspec-expectations-json
+
+library
+  exposed-modules:
+      Test.Hspec.Expectations.Json
+      Test.Hspec.Expectations.Json.Internal
+  other-modules:
+      Paths_hspec_expectations_json
+  hs-source-dirs:
+      library
+  default-extensions: BangPatterns DataKinds DeriveAnyClass DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies FlexibleContexts FlexibleInstances GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses NoImplicitPrelude NoMonomorphismRestriction OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TypeApplications TypeFamilies
+  build-depends:
+      Diff
+    , HUnit
+    , aeson
+    , aeson-pretty
+    , base >=4.11 && <5
+    , scientific
+    , text >1.2
+    , unordered-containers
+    , vector
+  default-language: Haskell2010
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Test.Hspec.Expectations.Json.InternalSpec
+      Test.Hspec.Expectations.JsonSpec
+      Paths_hspec_expectations_json
+  hs-source-dirs:
+      tests
+  default-extensions: BangPatterns DataKinds DeriveAnyClass DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies FlexibleContexts FlexibleInstances GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses NoImplicitPrelude NoMonomorphismRestriction OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TypeApplications TypeFamilies
+  build-depends:
+      aeson-qq
+    , base >=4.11 && <5
+    , hspec
+    , hspec-expectations-json
+  default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: hspec-expectations-json
-version: 1.0.0.3
+version: 1.0.0.4
 category: Test
 author: Freckle Engineering
 maintainer: engineering@freckle.com
@@ -65,10 +65,10 @@ library:
   dependencies:
     - Diff
     - HUnit
-    - aeson < 1.6
+    - aeson
     - aeson-pretty
     - scientific
-    - text > 1.2 && < 1.4
+    - text > 1.2
     - unordered-containers
     - vector
 


### PR DESCRIPTION
This is following the patterns of https://github.com/freckle/faktory_worker_haskell/pull/59

The only ways this differs are that it
 - updates the CHANGELOG and
 - includes the .cabal file 