### PR TITLE
Bump version for aeson release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,13 @@ jobs:
       - uses: freckle/stack-action@v2
         with:
           weeder: false
+          hlint: false
+
+  hlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: rwe/actions-hlint-setup@v1
+      - uses: rwe/actions-hlint-run@v2
+        with:
+          fail-on: warning

--- a/hspec-expectations-json.cabal
+++ b/hspec-expectations-json.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 03b32593f2d8b7a7fa1fd58625a86f4c674c7e9d06262a3a1210298e9c6f9421
+-- hash: 2249f4f5ffd0827d7a56b3b54bde96f866cf4cbf1356a68eef20779a8f93a3cd
 
 name:           hspec-expectations-json
-version:        1.0.0.4
+version:        1.0.0.5
 synopsis:       Hspec expectations for JSON Values
 description:    Hspec expectations for JSON Values
                 .

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: hspec-expectations-json
-version: 1.0.0.4
+version: 1.0.0.5
 category: Test
 author: Freckle Engineering
 maintainer: engineering@freckle.com


### PR DESCRIPTION
Commit https://github.com/freckle/hspec-expectations-json/commit/4f4fcb212b6acc936654eec3a0be3105a0ad5a9b was accidentally
pushed to `main`, but did not contain version bump. This commit sends
that version live.