### PR TITLE
Add MonadIO versions of our expectations

### DIFF
--- a/hspec-expectations-json.cabal
+++ b/hspec-expectations-json.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e19b1533eea5881244d80499fb25444f83558ff32ed38504fddb33e47c7322a4
+-- hash: a3f7ca52bc4458512b73169ea618ba58fa7becc1171fd1d17461ef1993b450b4
 
 name:           hspec-expectations-json
 version:        1.0.0.6
@@ -48,6 +48,7 @@ library
   exposed-modules:
       Test.Hspec.Expectations.Json
       Test.Hspec.Expectations.Json.Internal
+      Test.Hspec.Expectations.Json.Lifted
   other-modules:
       Paths_hspec_expectations_json
   hs-source-dirs:

--- a/library/Test/Hspec/Expectations/Json/Lifted.hs
+++ b/library/Test/Hspec/Expectations/Json/Lifted.hs
@@ -1,0 +1,25 @@
+module Test.Hspec.Expectations.Json.Lifted
+  ( shouldBeJson
+  , shouldBeUnorderedJson
+  , shouldMatchJson
+  , shouldMatchOrderedJson
+  ) where
+
+import Prelude
+
+import Control.Monad.IO.Class (MonadIO(..))
+import Data.Aeson
+import GHC.Stack
+import qualified Test.Hspec.Expectations.Json as E
+
+shouldBeJson :: (HasCallStack, MonadIO m) => Value -> Value -> m ()
+shouldBeJson x = liftIO . E.shouldBeJson x
+
+shouldBeUnorderedJson :: (HasCallStack, MonadIO m) => Value -> Value -> m ()
+shouldBeUnorderedJson x = liftIO . E.shouldBeUnorderedJson x
+
+shouldMatchJson :: (HasCallStack, MonadIO m) => Value -> Value -> m ()
+shouldMatchJson x = liftIO . E.shouldMatchJson x
+
+shouldMatchOrderedJson :: (HasCallStack, MonadIO m) => Value -> Value -> m ()
+shouldMatchOrderedJson x = liftIO . E.shouldMatchOrderedJson x


### PR DESCRIPTION
This is useful in non-IO specs, such as yesod-test.

Closes #4.
