### PR TITLE
Colorize diff in expectation failures

### DIFF
--- a/hspec-expectations-json.cabal
+++ b/hspec-expectations-json.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a3f7ca52bc4458512b73169ea618ba58fa7becc1171fd1d17461ef1993b450b4
+-- hash: 7b848593242e62894b5c63866d92afcf6c3b2c62cd15c3dd2254bf5b87d54fb6
 
 name:           hspec-expectations-json
 version:        1.0.0.6
@@ -47,6 +47,7 @@ source-repository head
 library
   exposed-modules:
       Test.Hspec.Expectations.Json
+      Test.Hspec.Expectations.Json.Color
       Test.Hspec.Expectations.Json.Internal
       Test.Hspec.Expectations.Json.Lifted
   other-modules:

--- a/library/Test/Hspec/Expectations/Json/Color.hs
+++ b/library/Test/Hspec/Expectations/Json/Color.hs
@@ -1,0 +1,30 @@
+module Test.Hspec.Expectations.Json.Color
+  ( Color(..)
+  , getColorize
+  ) where
+
+import Prelude
+
+import Control.Monad.IO.Class (MonadIO(..))
+import System.Environment (lookupEnv)
+import System.IO (hIsTerminalDevice, stdout)
+
+data Color = Reset | Red | Green
+
+getColorize :: MonadIO m => m (Color -> String -> String)
+getColorize = do
+  -- The stdout handle will not appear as a terminal on GitHub Actions, but it
+  -- does support color escapes.
+  shouldColorize <-
+    liftIO $ (||) <$> isGitHubActions <*> hIsTerminalDevice stdout
+
+  pure $ if shouldColorize
+    then \c x -> escape Reset <> escape c <> x <> escape Reset
+    else \_ x -> x
+  where isGitHubActions = (== Just "true") <$> lookupEnv "GITHUB_ACTIONS"
+
+escape :: Color -> String
+escape = \case
+  Reset -> "\ESC[0m"
+  Red -> "\ESC[0;31m"
+  Green -> "\ESC[0;32m"

--- a/library/Test/Hspec/Expectations/Json/Internal.hs
+++ b/library/Test/Hspec/Expectations/Json/Internal.hs
@@ -43,20 +43,22 @@ import Data.Vector (Vector)
 import qualified Data.Vector as V
 import GHC.Stack (HasCallStack)
 import qualified Test.HUnit as HUnit
+import Test.Hspec.Expectations.Json.Color
 
 -- So we can call HashMap KeyMap in older aeson
 {-# ANN module ("HLint: ignore Avoid restricted qualification" :: String) #-}
 
 assertBoolWithDiff :: HasCallStack => Bool -> Text -> Text -> IO ()
-assertBoolWithDiff asserting expected got =
-  flip HUnit.assertBool asserting . unlines . map addSign $ getDiff
+assertBoolWithDiff asserting expected got = do
+  colorize <- getColorize
+  flip HUnit.assertBool asserting . unlines . map (addSign colorize) $ getDiff
     (lines (T.unpack expected))
     (lines (T.unpack got))
  where
-  addSign = \case
-    Both _ s -> "   " ++ s
-    First s -> "---" ++ s
-    Second s -> "+++" ++ s
+  addSign colorize = \case
+    Both _ s -> colorize Reset $ "   " ++ s
+    First s -> colorize Red $ "---" ++ s
+    Second s -> colorize Green $ "+++" ++ s
 
 newtype Superset = Superset Value
 

--- a/tests/Test/Hspec/Expectations/JsonSpec.hs
+++ b/tests/Test/Hspec/Expectations/JsonSpec.hs
@@ -2,8 +2,7 @@
 
 module Test.Hspec.Expectations.JsonSpec
   ( spec
-  )
-where
+  ) where
 
 import Prelude
 
@@ -111,3 +110,40 @@ spec = do
         |]
 
       a `shouldMatchJson` b
+
+    -- it "is an example failure, to checking how they're printed" $ do
+    --   let
+    --     a = [aesonQQ|
+    --       [ { "shortName": "B"
+    --         , "subSkills":
+    --           [ { "shortName": "1"
+    --             , "uspId": "68fa5xxxxxxxx332f7c88884e5c40e"
+    --             }
+    --           ]
+    --         }
+    --       , { "shortName": "A"
+    --         , "subSkills":
+    --              [ { "shortName": "a"
+    --                , "uspId": "71839723561ba1a49cf2a789dbe50302"
+    --                }
+    --              , { "shortName": "b"
+    --                , "uspId": "4096d2cfebcab73438971ae2304544ee"
+    --                }
+    --              ]
+    --         }
+    --       ]
+    --     |]
+    --     b = [aesonQQ|
+    --       [ { "subSkills":
+    --           [ { "uspId": "71839723561ba1a49cf2a789dbe50302" }
+    --           , { "uspId": "4096d2cfebcab73438971ae2304544ee" }
+    --           ]
+    --         }
+    --       , { "subSkills":
+    --           [ { "uspId": "68fa57ddbc1e9aa332f7c88884e5c40e" }
+    --           ]
+    --         }
+    --       ]
+    --     |]
+
+    --   a `shouldMatchJson` b


### PR DESCRIPTION
Our needs are very simple, so I chose to construct the escapes by hand.
Our preferred library (ansi-terminal) is better for setting escapes
_while printing_, but we're constructing a failure message and don't
control actual printing. I also special-cased GitHub Actions, since I
happen to know it doesn't respond like a terminal but does support these
escapes.

Closes #3.
