### PR TITLE
Enforce equals invariant for matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [_Unreleased_](https://github.com/freckle/hspec-expectations-json/compare/v1.0.1.0...main)
 
+## [v1.0.1.1](https://github.com/freckle/hspec-expectations-json/compare/v1.0.1.0...v1.0.1.1)
+
+- Add invariant for all matchers for equality. (ex: forall a. a `shouldMatchJson` a)
+
 ## [v1.0.1.0](https://github.com/freckle/hspec-expectations-json/compare/v1.0.0.6...v1.0.1.0)
 
 - Colorize diff in expectation failure, if connected to a terminal or running on

--- a/hspec-expectations-json.cabal
+++ b/hspec-expectations-json.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f5fa8c4645f2ec76ec6837564deafa8d5399ad48fdc64b04351fbd44381229db
+-- hash: 19cac3e800b693fe2abef985d22d3e12b8fa461d817f987c2279a69ca839ccad
 
 name:           hspec-expectations-json
 version:        1.0.0.7
@@ -127,6 +127,7 @@ test-suite spec
       TypeFamilies
   build-depends:
       QuickCheck
+    , aeson
     , aeson-qq
     , base >=4.11 && <5
     , hspec

--- a/hspec-expectations-json.cabal
+++ b/hspec-expectations-json.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d1ebf85fa8ddd727064f9ff9a81c133512ce7165a7bf9e67002dff04467c1cfd
+-- hash: f5fa8c4645f2ec76ec6837564deafa8d5399ad48fdc64b04351fbd44381229db
 
 name:           hspec-expectations-json
 version:        1.0.0.7
@@ -126,7 +126,8 @@ test-suite spec
       TypeApplications
       TypeFamilies
   build-depends:
-      aeson-qq
+      QuickCheck
+    , aeson-qq
     , base >=4.11 && <5
     , hspec
     , hspec-expectations-json

--- a/library/Test/Hspec/Expectations/Json.hs
+++ b/library/Test/Hspec/Expectations/Json.hs
@@ -34,6 +34,7 @@ import Data.Text.Lazy (toStrict)
 import Data.Text.Lazy.Encoding (decodeUtf8)
 import GHC.Stack
 import Test.Hspec.Expectations.Json.Internal
+import Control.Monad (unless)
 
 -- $setup
 -- >>> :set -XQuasiQuotes
@@ -94,7 +95,8 @@ infix 1 `shouldBeJson`
 --    }
 --
 shouldBeUnorderedJson :: HasCallStack => Value -> Value -> IO ()
-shouldBeUnorderedJson a b = sortJsonArrays a `shouldBeJson` sortJsonArrays b
+shouldBeUnorderedJson a b = unless (a == b) $
+  sortJsonArrays a `shouldBeJson` sortJsonArrays b
 
 infix 1 `shouldBeUnorderedJson`
 
@@ -122,7 +124,7 @@ infix 1 `shouldBeUnorderedJson`
 --    }
 --
 shouldMatchJson :: HasCallStack => Value -> Value -> IO ()
-shouldMatchJson sup sub =
+shouldMatchJson sup sub = unless (sup == sub) $
   sortJsonArrays (pruneJson (Superset sup) (Subset sub))
     `shouldBeJson` sortJsonArrays sub
 
@@ -130,7 +132,7 @@ infix 1 `shouldMatchJson`
 
 -- | Compare JSON values with the same semantics as 'shouldMatchJson'
 matchesJson :: Value -> Value -> Bool
-matchesJson sup sub =
+matchesJson sup sub = sup == sub ||
   sortJsonArrays (pruneJson (Superset sup) (Subset sub)) == sortJsonArrays sub
 
 -- | 'shouldBeJson', ignoring extra Object keys
@@ -159,7 +161,7 @@ matchesJson sup sub =
 --    }
 --
 shouldMatchOrderedJson :: HasCallStack => Value -> Value -> IO ()
-shouldMatchOrderedJson sup sub =
+shouldMatchOrderedJson sup sub = unless (sup == sub) $
   pruneJson (Superset sup) (Subset sub) `shouldBeJson` sub
 
 infix 1 `shouldMatchOrderedJson`

--- a/library/Test/Hspec/Expectations/Json.hs
+++ b/library/Test/Hspec/Expectations/Json.hs
@@ -23,18 +23,17 @@ module Test.Hspec.Expectations.Json
   -- * As predicates
   -- | These are only created when a specific need arises
   , matchesJson
-  )
-where
+  ) where
 
 import Prelude
 
+import Control.Monad (unless)
 import Data.Aeson
 import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.Text.Lazy (toStrict)
 import Data.Text.Lazy.Encoding (decodeUtf8)
 import GHC.Stack
 import Test.Hspec.Expectations.Json.Internal
-import Control.Monad (unless)
 
 -- $setup
 -- >>> :set -XQuasiQuotes
@@ -95,8 +94,8 @@ infix 1 `shouldBeJson`
 --    }
 --
 shouldBeUnorderedJson :: HasCallStack => Value -> Value -> IO ()
-shouldBeUnorderedJson a b = unless (a == b) $
-  sortJsonArrays a `shouldBeJson` sortJsonArrays b
+shouldBeUnorderedJson a b =
+  unless (a == b) $ sortJsonArrays a `shouldBeJson` sortJsonArrays b
 
 infix 1 `shouldBeUnorderedJson`
 
@@ -124,16 +123,20 @@ infix 1 `shouldBeUnorderedJson`
 --    }
 --
 shouldMatchJson :: HasCallStack => Value -> Value -> IO ()
-shouldMatchJson sup sub = unless (sup == sub) $
-  sortJsonArrays (pruneJson (Superset sup) (Subset sub))
+shouldMatchJson sup sub =
+  unless (sup == sub)
+    $ sortJsonArrays (pruneJson (Superset sup) (Subset sub))
     `shouldBeJson` sortJsonArrays sub
 
 infix 1 `shouldMatchJson`
 
 -- | Compare JSON values with the same semantics as 'shouldMatchJson'
 matchesJson :: Value -> Value -> Bool
-matchesJson sup sub = sup == sub ||
-  sortJsonArrays (pruneJson (Superset sup) (Subset sub)) == sortJsonArrays sub
+matchesJson sup sub =
+  sup
+    == sub
+    || sortJsonArrays (pruneJson (Superset sup) (Subset sub))
+    == sortJsonArrays sub
 
 -- | 'shouldBeJson', ignoring extra Object keys
 --
@@ -161,7 +164,7 @@ matchesJson sup sub = sup == sub ||
 --    }
 --
 shouldMatchOrderedJson :: HasCallStack => Value -> Value -> IO ()
-shouldMatchOrderedJson sup sub = unless (sup == sub) $
-  pruneJson (Superset sup) (Subset sub) `shouldBeJson` sub
+shouldMatchOrderedJson sup sub =
+  unless (sup == sub) $ pruneJson (Superset sup) (Subset sub) `shouldBeJson` sub
 
 infix 1 `shouldMatchOrderedJson`

--- a/package.yaml
+++ b/package.yaml
@@ -77,6 +77,7 @@ tests:
     main: Spec.hs
     source-dirs: tests
     dependencies:
+      - aeson
       - aeson-qq
       - hspec
       - hspec-expectations-json

--- a/package.yaml
+++ b/package.yaml
@@ -80,3 +80,4 @@ tests:
       - aeson-qq
       - hspec
       - hspec-expectations-json
+      - QuickCheck

--- a/tests/Test/Hspec/Expectations/JsonSpec.hs
+++ b/tests/Test/Hspec/Expectations/JsonSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE QuasiQuotes #-}
 
 module Test.Hspec.Expectations.JsonSpec
@@ -11,10 +12,17 @@ import Test.Hspec
 import Test.Hspec.Expectations.Json
 import Test.Hspec.QuickCheck (prop)
 
+matchesJsonTest :: SpecWith ()
+#if MIN_VERSION_aeson(2,0,3)
+matchesJsonTest = describe "matchesJson" $ do
+  prop "always matches itself" $ \a -> a `matchesJson` a
+#else
+matchesJsonTest = pure ()
+#endif
+
 spec :: Spec
 spec = do
-  describe "matchesJson" $ do
-    prop "always matches itself" $ \a -> a `matchesJson` a
+  matchesJsonTest
 
   describe "shouldMatchJson" $ do
     it "matches itself" $ do

--- a/tests/Test/Hspec/Expectations/JsonSpec.hs
+++ b/tests/Test/Hspec/Expectations/JsonSpec.hs
@@ -18,7 +18,7 @@ spec = do
 
   describe "shouldMatchJson" $ do
     it "matches itself" $ do
-      let 
+      let
         a = [aesonQQ|[{id:1}, {id:2, a:"a"}]|]
         b = [aesonQQ|[{id:1, a:"a"}, {id:2}]|]
         c = [aesonQQ|[{id:1, a:"a"}, {id:2, a:"a"}]|]

--- a/tests/Test/Hspec/Expectations/JsonSpec.hs
+++ b/tests/Test/Hspec/Expectations/JsonSpec.hs
@@ -9,10 +9,22 @@ import Prelude
 import Data.Aeson.QQ
 import Test.Hspec
 import Test.Hspec.Expectations.Json
+import Test.Hspec.QuickCheck (prop)
 
 spec :: Spec
 spec = do
+  describe "matchesJson" $ do
+    prop "always matches itself" $ \a -> a `matchesJson` a
+
   describe "shouldMatchJson" $ do
+    it "matches itself" $ do
+      let 
+        a = [aesonQQ|[{id:1}, {id:2, a:"a"}]|]
+        b = [aesonQQ|[{id:1, a:"a"}, {id:2}]|]
+        c = [aesonQQ|[{id:1, a:"a"}, {id:2, a:"a"}]|]
+      a `shouldMatchJson` a
+      b `shouldMatchJson` b
+      c `shouldMatchJson` c
     it "passes regardless of array order" $ do
       let
         a = [aesonQQ|[{ "foo": 1 }, { "foo": 0 }]|]

--- a/tests/Test/Hspec/Expectations/JsonSpec.hs
+++ b/tests/Test/Hspec/Expectations/JsonSpec.hs
@@ -25,7 +25,7 @@ spec = do
       a `shouldMatchJson` a
       b `shouldMatchJson` b
       c `shouldMatchJson` c
-      
+
     it "passes regardless of array order" $ do
       let
         a = [aesonQQ|[{ "foo": 1 }, { "foo": 0 }]|]

--- a/tests/Test/Hspec/Expectations/JsonSpec.hs
+++ b/tests/Test/Hspec/Expectations/JsonSpec.hs
@@ -25,6 +25,7 @@ spec = do
       a `shouldMatchJson` a
       b `shouldMatchJson` b
       c `shouldMatchJson` c
+      
     it "passes regardless of array order" $ do
       let
         a = [aesonQQ|[{ "foo": 1 }, { "foo": 0 }]|]

--- a/tests/Test/Hspec/Expectations/JsonSpec.hs
+++ b/tests/Test/Hspec/Expectations/JsonSpec.hs
@@ -10,7 +10,9 @@ import Prelude
 import Data.Aeson.QQ
 import Test.Hspec
 import Test.Hspec.Expectations.Json
+#if MIN_VERSION_aeson(2,0,3)
 import Test.Hspec.QuickCheck (prop)
+#endif
 
 matchesJsonTest :: SpecWith ()
 #if MIN_VERSION_aeson(2,0,3)


### PR DESCRIPTION
Matchers should never fail to match when two things are strictly equal.
This ensures that we check for equality before running any matching
algorithms.