### PR TITLE
Fix issue with nested objects and expandHeterogenousArrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [_Unreleased_](https://github.com/freckle/hspec-expectations-json/compare/v1.0.2.1...main)
 
-## [v1.0.3.0](https://github.com/freckle/hspec-expectations-json/compare/v1.0.2.0...v1.0.2.1)
+## [v1.0.2.1](https://github.com/freckle/hspec-expectations-json/compare/v1.0.2.0...v1.0.2.1)
 
 - Fixed issue with `expandHeterogenousArrays` not working for nested Objects
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/hspec-expectations-json/compare/v1.0.1.0...main)
+## [_Unreleased_](https://github.com/freckle/hspec-expectations-json/compare/v1.0.2.1...main)
+
+## [v1.0.3.0](https://github.com/freckle/hspec-expectations-json/compare/v1.0.2.0...v1.0.2.1)
+
+- Fixed issue with `expandHeterogenousArrays` not working for nested Objects
 
 ## [v1.0.2.0](https://github.com/freckle/hspec-expectations-json/compare/v1.0.1.1...v1.0.2.0)
 

--- a/hspec-expectations-json.cabal
+++ b/hspec-expectations-json.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 088c15398e478d5dc849fc5c4cca94a30a77df897ef2b42ecd8b0106672134d2
+-- hash: ef9861c1b5d79d28d7f37c9ab349220eff3d7cee9b9467839c319bc306a9a219
 
 name:           hspec-expectations-json
-version:        1.0.2.0
+version:        1.0.2.1
 synopsis:       Hspec expectations for JSON Values
 description:    Hspec expectations for JSON Values
                 .

--- a/library/Test/Hspec/Expectations/Json/Internal.hs
+++ b/library/Test/Hspec/Expectations/Json/Internal.hs
@@ -128,7 +128,7 @@ expandHeterogenousArrays = go mempty
             vec
       in
         Object $ nullChildren nullCurrentLevel
-    Array vec -> Array $ go vec <$> vec
+    Array v -> Array $ go v <$> v
     x -> x
 
 newtype Sortable = Sortable Value

--- a/library/Test/Hspec/Expectations/Json/Internal.hs
+++ b/library/Test/Hspec/Expectations/Json/Internal.hs
@@ -102,14 +102,34 @@ pruneJson (Superset sup) (Subset sub) = case (sup, sub) of
 --
 -- ex: [{a:1}, {b:1}] -> [{a:1, b:null}, {a:null, b:1}]
 expandHeterogenousArrays :: Value -> Value
-expandHeterogenousArrays = go KeyMap.empty
+expandHeterogenousArrays = go mempty
  where
   collectAllKeys = \case
     Object km -> Null <$ km
     _ -> KeyMap.empty
-  go allKeys = \case
-    Object km -> Object $ expandHeterogenousArrays <$> KeyMap.union km allKeys
-    Array vec -> Array $ go (foldMap collectAllKeys vec) <$> vec
+  go vec = \case
+    Object km ->
+      let
+        -- Set all keys not present in this level of the object to null
+        nullCurrentLevel :: Object
+        nullCurrentLevel = KeyMap.union km (foldMap collectAllKeys vec)
+        -- `mapWithKey` is not available for all version of `KeyMap`
+        mapWithKey f = KeyMap.fromList . fmap f . KeyMap.toList
+        -- Recurse over all properties
+        nullChildren :: Object -> Object
+        nullChildren = mapWithKey $ \(k, v) -> (k, go (siblingProperties k) v)
+        -- Gather all values at the specified key
+        siblingProperties :: Key -> Array
+        siblingProperties k =
+          V.mapMaybe
+            ( \case
+                Object km' -> KeyMap.lookup k km'
+                _ -> Nothing
+            )
+            vec
+      in
+        Object $ nullChildren nullCurrentLevel
+    Array vec -> Array $ go vec <$> vec
     x -> x
 
 newtype Sortable = Sortable Value

--- a/library/Test/Hspec/Expectations/Json/Internal.hs
+++ b/library/Test/Hspec/Expectations/Json/Internal.hs
@@ -119,7 +119,6 @@ expandHeterogenousArrays = go mempty
         nullChildren :: Object -> Object
         nullChildren = mapWithKey $ \(k, v) -> (k, go (siblingProperties k) v)
         -- Gather all values at the specified key
-        siblingProperties :: Key -> Array
         siblingProperties k =
           V.mapMaybe
             ( \case

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: hspec-expectations-json
-version: 1.0.2.0
+version: 1.0.2.1
 category: Test
 author: Freckle Engineering
 maintainer: engineering@freckle.com

--- a/tests/Test/Hspec/Expectations/JsonSpec.hs
+++ b/tests/Test/Hspec/Expectations/JsonSpec.hs
@@ -159,6 +159,57 @@ spec = do
 
       a `shouldMatchJsonWithOmittedNullFields` b
 
+    it "ignores omitted null fields in nested objects" $ do
+      let
+        a =
+          [aesonQQ|
+[
+  {
+    "a": {
+      "a": 1
+    },
+    "b": {
+      "b": 1
+    }
+  },
+  {
+    "a": {
+      "b": 2
+    },
+    "b": {
+      "c": 2
+    }
+  }
+]
+|]
+        b =
+          [aesonQQ|
+[
+  {
+    "a": {
+      "a": 1,
+      "b": null
+    },
+    "b": {
+      "b": 1,
+      "c": null
+    }
+  },
+  {
+    "a": {
+      "a": null,
+      "b": 2
+    },
+    "b": {
+      "b": null,
+      "c": 2
+    }
+  }
+]
+|]
+
+      a `shouldMatchJsonWithOmittedNullFields` b
+
 -- it "is an example failure, to checking how they're printed" $ do
 --   let
 --     a = [aesonQQ|


### PR DESCRIPTION
`expandHeterogenousArrays` only expands the top-level properties of an Object instead of deeply expanding as is expected.

This recurses the properties of an object to deeply expand them.